### PR TITLE
change t.id to t.user_id in main.py

### DIFF
--- a/twitter_api/main.py
+++ b/twitter_api/main.py
@@ -73,7 +73,7 @@ def logout(user_id):
 @app.route('/tweet/<int:tweet_id>')
 def get_tweet(tweet_id):
     query = """SELECT t.id, t.content, t.created, u.username
-        FROM tweet t INNER JOIN user u ON u.id == t.id
+        FROM tweet t INNER JOIN user u ON u.id == t.user_id
         WHERE t.id=:tweet_id;
     """
 


### PR DESCRIPTION
In the `get_tweet` view function, the query containing the join between the user table and the tweet table should be based on `t.user_id` for the tweet table, not `t.id`. This pull requests Fixes #41.